### PR TITLE
non-op players couldn't make a welcome sign

### DIFF
--- a/src/main/java/bentobox/addon/warps/Warp.java
+++ b/src/main/java/bentobox/addon/warps/Warp.java
@@ -97,8 +97,7 @@ public class Warp extends Addon {
     }
 
     public String getPermPrefix(World world) {
-        this.getPlugin().getIWM().getPermissionPrefix(world);
-        return null;
+        return this.getPlugin().getIWM().getPermissionPrefix(world);
     }
 
     /**

--- a/src/main/java/bentobox/addon/warps/WarpSignsListener.java
+++ b/src/main/java/bentobox/addon/warps/WarpSignsListener.java
@@ -68,7 +68,7 @@ public class WarpSignsListener implements Listener {
                 // Welcome sign detected - check to see if it is
                 // this player's sign
                 if ((list.containsKey(user.getUniqueId()) && list.get(user.getUniqueId()).equals(s.getLocation()))
-                        || user.isOp()  || user.hasPermission(addon.getPermPrefix(e.getBlock().getWorld()) + "mod.removesign")) {
+                        || user.isOp()  || user.hasPermission(addon.getPermPrefix(e.getBlock().getWorld()) + ".mod.removesign")) {
                     addon.getWarpSignsManager().removeWarp(s.getLocation());
                     Bukkit.getPluginManager().callEvent(new WarpRemoveEvent(addon, s.getLocation(), user.getUniqueId()));
                 } else {
@@ -96,9 +96,9 @@ public class WarpSignsListener implements Listener {
         // Check if someone is changing their own sign
         if (title.equalsIgnoreCase(addon.getConfig().getString("welcomeLine"))) {
             // Welcome sign detected - check permissions
-            if (!(user.hasPermission(addon.getPermPrefix(b.getWorld()) + "island.addwarp"))) {
+            if (!(user.hasPermission(addon.getPermPrefix(b.getWorld()) + ".island.addwarp"))) {
                 user.sendMessage("warps.error.no-permission");
-                user.sendMessage("general.errors.you-need", "[permission]", addon.getPermPrefix(b.getWorld()) + "island.addwarp");
+                user.sendMessage("general.errors.you-need", "[permission]", addon.getPermPrefix(b.getWorld()) + ".island.addwarp");
                 return;
             }
             long level = plugin.getAddonsManager().getAddonByName(LEVEL_PLUGIN_NAME).map(l -> (Level)l)

--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -10,7 +10,13 @@ permissions:
   bskyblock.island.warp:
     description: Player can use warp or warps commands
     default: true
+  bskyblock.island.addwarp:
+    description: Player can create a welcome warp sign
+    default: true
   acidisland.island.warp:
     description: Player can use warp or warps commands
+    default: true
+  acidisland.island.addwarp:
+    description: Player can create a welcome warp sign
     default: true
 


### PR DESCRIPTION
The addwarp permission was missing from addon.yml
getPermPrefix was returning null instead of the actual prefix
and needed to add '.'
 